### PR TITLE
expand comparison path for Windows compat

### DIFF
--- a/spec/bundler/shared_helpers_spec.rb
+++ b/spec/bundler/shared_helpers_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Bundler::SharedHelpers do
     before { ENV["BUNDLE_GEMFILE"] = "/path/Gemfile" }
 
     context "Gemfile is present" do
-      let(:expected_gemfile_path) { Pathname.new("/path/Gemfile") }
+      let(:expected_gemfile_path) { Pathname.new("/path/Gemfile").expand_path }
 
       it "returns the Gemfile path" do
         expect(subject.default_gemfile).to eq(expected_gemfile_path)


### PR DESCRIPTION
which adds a `C:` to the path

Thanks so much for the contribution!
To make reviewing this PR a bit easier, please fill out answers to the following questions.

### What was the end-user problem that led to this PR?

The problem was...

### What was your diagnosis of the problem?

My diagnosis was...

### What is your fix for the problem, implemented in this PR?

My fix...

### Why did you choose this fix out of the possible options?

I chose this fix because...
